### PR TITLE
Some fixes and improvement

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,19 +116,19 @@ void idle() {
 }
 
 void initGL() {
-	glClearColor(0.0, 0.0, 0.0, 0.0);
+	glClearColor(0.0, 0.0, 0.0, 0.0);//set background to black
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();
 	gluOrtho2D(0, SCREEN_WIDTH, 0, SCREEN_HEIGHT);
 }
 
 int main(int argc, char** argv) {
-	glutInitDisplayMode(GLUT_DOUBLE);
-	glutInit(&argc, argv);
-	glutInitWindowSize(SCREEN_WIDTH, SCREEN_HEIGHT);
-	glutCreateWindow("our program \u262d");
-	glutDisplayFunc(display);
-	glutIdleFunc(idle);
+	glutInit(&argc, argv);//initialise glut library
+	glutInitDisplayMode(GLUT_DOUBLE);//set displaymode to double buffered window
+	glutInitWindowSize(SCREEN_WIDTH, SCREEN_HEIGHT);//set window size
+	glutCreateWindow("our program \u262d");//set window name
+	glutDisplayFunc(display);//callback function, redraw when window is updated
+	glutIdleFunc(idle);//execute idle function when there is no user input
 	initGL();
 	glutMainLoop();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,10 +18,10 @@
 #define PI 3.1415926535897932384626433832795
 #define FPS 30
 
-int X = 0;
-int Y = 0;
-int dx = 5;
-int dy = 6;
+double X = 0;
+double Y = 0;
+double dx = 2.5;
+double dy = 3.0;
 
 void nGon(int x, int y, int r, int n) {
 	double inc = (2 * PI) / n;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,8 +13,8 @@
 #endif
 #include <time.h>
 
-#define SCREEN_WIDTH 800
-#define SCREEN_HEIGHT 800
+#define SCREEN_WIDTH 1280
+#define SCREEN_HEIGHT 720
 #define PI 3.1415926535897932384626433832795
 #define FPS 30
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -108,6 +108,10 @@ void idle() {
 	if (X<0 || X > SCREEN_WIDTH) dx *= -1;
 	if (Y<0 || Y > SCREEN_HEIGHT) dy *= -1;
 
+	//while (GetTickCount() - start < 1000 / FPS) {}; 
+	/*start shows undefined in intellisense but we have already defined it above, ignore it.
+	this while function is being used to limit the FPS to the defined FPS value.
+	*/
 	glutPostRedisplay();
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -99,8 +99,6 @@ void display() {
 void idle() {
 	
 	unsigned int start = GetTickCount();
-	while (GetTickCount() - start < 1000 / FPS) {}; //start shows undefined in intellisense but we have already defined it above, ignore it.
-
 
 	X += dx;
 	Y += dy;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,7 @@
 #define SCREEN_WIDTH 1280
 #define SCREEN_HEIGHT 720
 #define PI 3.1415926535897932384626433832795
-#define FPS 30
+#define FPS 60
 
 double X = 0;
 double Y = 0;


### PR DESCRIPTION
I noticed that the way frames are limited is by executing an empty while loop by comparing the the tick count to the ratio of 1 second to 30 frames. This method is more or less like a sleep function that slows down the actual code execution (basically, slows down time instead of limiting frames).

Another change was the X and Y coordinates were initially in int instead of double so the transition is not smooth.